### PR TITLE
Questionable fix for #17 - deleteByQuery not following API

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -155,11 +155,11 @@ module.exports = function (config, req, self) {
 
 		options.pathname = utils.pathAppend(index) +
 			utils.pathAppend(type) +
-			utils.pathAppend('_query');
+			utils.pathAppend('_query?source=' + encodeURIComponent(JSON.stringify(query)));
 
-		// documentation indicates DELETE method...
-		// sending POST data via DELETE not typical, using POST instead
-		return req.post(options, query, callback);
+		// sending POST data via DELETE not typical
+		// instead sending data as 'source' parameter in querystring
+		return req.delete(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/get/
@@ -224,11 +224,11 @@ module.exports = function (config, req, self) {
 		options.pathname = utils.pathAppend(index) +
 			utils.pathAppend(type) +
 			utils.pathAppend(options._id) +
-			utils.pathAppend('_explain');
+			utils.pathAppend('_explain?source=' + encodeURIComponent(JSON.stringify(query)));
 
-		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, query, callback);
+		// sending POST data via GET not typical
+		// instead sending data as 'source' parameter in querystring
+		return req.get(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/get/
@@ -362,11 +362,11 @@ module.exports = function (config, req, self) {
 			return callback(new Error('at least 1 or more docs supplied is missing type'));
 		}
 
-		options.pathname = utils.pathAppend('_mget');
+		options.pathname = utils.pathAppend('_mget?source=' + encodeURIComponent(JSON.stringify(docs)));
 
-		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, docs, callback);
+		// sending POST data via GET not typical
+		// instead sending data as 'source' parameter in querystring
+		return req.get(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/multi-search/
@@ -394,18 +394,18 @@ module.exports = function (config, req, self) {
 
 		options.query = utils.exclude(options, paramExcludes);
 
-		options.pathname = utils.pathAppend(index) +
-			(index ? utils.pathAppend(type) : '') +
-			utils.pathAppend('_msearch');
-
 		queries.forEach(function (query) {
 			serializedQueries += JSON.stringify(query);
 			serializedQueries += '\n';
 		});
 
-		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, serializedQueries, callback);
+		options.pathname = utils.pathAppend(index) +
+			(index ? utils.pathAppend(type) : '') +
+			utils.pathAppend('_msearch?source=' + encodeURIComponent(serializedQueries));
+
+		// sending POST data via GET not typical
+		// instead sending data as 'source' parameter in querystring
+		return req.get(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/percolate/
@@ -429,11 +429,11 @@ module.exports = function (config, req, self) {
 
 		options.pathname = utils.pathAppend(index) +
 			utils.pathAppend(type) +
-			utils.pathAppend('_percolate');
+			utils.pathAppend('_percolate?source=' + encodeURIComponent(JSON.stringify(doc)));
 
-		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, doc, callback);
+		// sending POST data via GET not typical
+		// instead sending data as 'source' parameter in querystring
+		return req.get(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/percolate/
@@ -483,11 +483,11 @@ module.exports = function (config, req, self) {
 
 		options.pathname = utils.pathAppend(index) +
 			utils.pathAppend(type) +
-			utils.pathAppend('_search');
+			utils.pathAppend('_search?source=' + encodeURIComponent(JSON.stringify(query)));
 
 		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, query, callback);
+		// instead sending data as 'source' parameter in querystring
+		return req.get(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/percolate/
@@ -566,11 +566,11 @@ module.exports = function (config, req, self) {
 
 		options.pathname = utils.pathAppend(index) +
 			utils.pathAppend(type) +
-			utils.pathAppend('_validate/query');
+			utils.pathAppend('_validate/query?source=' + encodeURIComponent(JSON.stringify(query)));
 
 		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, query, callback);
+		// instead sending data as 'source' parameter in querystring
+		return req.get(options, callback);
 	};
 
 	return self;


### PR DESCRIPTION
Questionable fix for the API methods that would require sending a request entity for HTTP methods that technically don't allow request entities.  Fix involves serializing the object that would be passed as the request body, then passing it as the value of the "source" param in the URL query-string.

I personally would prefer for this library to just grit its teeth and send request content where the ES API supports it, btw.

N.B. The only piece of this commit that I've tested against an ES installation is the deleteByQuery method.
