### PR TITLE
Fix bulkIndex to work with documents that have _id

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -66,12 +66,16 @@ module.exports = function (config, req, self) {
 			type = utils.getTypeSyntax(options, config);
 
 		documents.forEach(function (document) {
-			commands.push({
+			var documentConf = {
 				index : {
 					_index : index,
 					_type : type
 				}
-			});
+			}
+			if (document._id) {
+				documentConf.index._id = document._id;
+			}
+			commands.push(documentConf);
 			commands.push(document);
 		});
 


### PR DESCRIPTION
bulkIndex fails for documents that have _id.
This PR fixes that by looking at each document's _id (if exists) and assigning them to the configuration object pushed into the array. 

(note: I actually implemented the same thing in my code in coffeescript and it works well. I then backported to this PR in JS, so I never actually ran the JS code as is. But it's a simple fix...)
