### PR TITLE
Different ports support with hosts option

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -185,6 +185,16 @@ exports.initialize = function (settings, self) {
 		Object.keys(options).forEach(function (field) {
 			returnOptions[field] = options[field];
 		});
+		
+		// default port is 80, that will interfere when we have different ports
+		var hostKey = returnOptions.host ? "host" : "hostname";
+		var hostData = returnOptions[hostKey];
+		if (!returnOptions.port && hostData.indexOf(":") != -1) {
+			var hostAndPort = hostData.split(":");
+			// we may have no port after :, but then it was malformed anyway
+			returnOptions[hostKey] = hostAndPort[0];
+			returnOptions.port = hostAndPort[1];
+		}
 
 		// ensure default timeout is applied if one is not supplied
 		if (typeof returnOptions.timeout === 'undefined') {


### PR DESCRIPTION
I had a very unpleasant bug today - supplied hosts with multiple ports as it says in the docs, and of course had an issue with ENOTFOUND, because port was never stripped off from the host itself and the connection had the following destination at all times: xxx.xxx.xxx.xxx:port:80

This fixes it. Might be a bit dirty, but does the job
