### PR TITLE
Added support for ElasticSearch 5.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4.2"
 services: elasticsearch
 before_install:
   - sudo service elasticsearch stop
 #  - sudo apt-get upgrade elasticsearch
-  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.0.deb
-  - sudo dpkg -i --force-confnew elasticsearch-1.7.0.deb
+  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-5.5.0.deb
+  - sudo dpkg -i --force-confnew elasticsearch-5.5.0.deb
   - sudo service elasticsearch start
 after_success:
   - npm install -g coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services: elasticsearch
 before_install:
   - sudo service elasticsearch stop
 #  - sudo apt-get upgrade elasticsearch
-  - wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-5.5.0.deb
+  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.deb
   - sudo dpkg -i --force-confnew elasticsearch-5.5.0.deb
   - sudo service elasticsearch start
 after_success:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,15 @@
+# v0.6.0 / 2017-10-02
+
+* Modified to support ElasticSearch 5.5.x
+  * `indices.createIndex` method adjusted to only call `put` (deprecated `post`)
+  * `indices.optimize` method deprecated
+  * `indices.status` method deprecated
+  * `Warmers` deprecated
+  * `Percolators` deprecated
+  * `scan` search_type deprecated
+  * `and` filter deprecate and replaced by `bool` query
+  * unit and functional tests udpated
+
 # v0.5.2 / 2016-10-05
 
 * Added fix for scenario where `_index` and `_type` overrides would not always work (Issue #62)

--- a/README.md
+++ b/README.md
@@ -412,22 +412,6 @@ If `_index` and/or `_type` are supplied via options (or lib config), the will ap
 
 `es.multiSearch(options, queries, callback)`
 
-##### Percolate
-
-Requires `_index` be specified either via lib config or via options when calling the operation.
-
-`es.percolate(options, doc, callback)`
-
-Requires `_index` be specified either via lib config or via options when calling the operation.
-Also requires `_id`, but this must be specified via options.
-
-`es.registerPercolator(options, query, callback)`
-
-Requires `_index` be specified either via lib config or via options when calling the operation.
-Also requires `_id`, but this must be specified via options.
-
-`es.unregisterPercolator(options, callback)`
-
 ##### Search
 
 Requires `_index` be specified either via lib config or via options when calling the operation.
@@ -446,9 +430,8 @@ var
   },
   es = elasticsearch(config);
 
-// first search, specifying scan search_type
+// first search
 es.search({
-    search_type : 'scan',
     scroll : '10m'
   }, {
     query : {
@@ -541,13 +524,6 @@ Requires `name`, but this must be specified via options.
 
 `es.indices.deleteTemplate(options, callback)`
 
-##### Delete Warmer
-
-Requires `_index` be specified either via lib config or via options when calling the operation.
-Also requires `name`, but this must be specified via options.
-
-`es.indices.deleteWarmer(options, callback)`
-
 ##### Exists
 
 Requires `_index` be specified either via lib config or via options when calling the operation.
@@ -568,21 +544,11 @@ Requires `_index` be specified either via lib config or via options when calling
 
 `es.indices.openIndex(options, callback)`
 
-##### Optimize
-
-`es.indices.optimize(options, callback)`
-
 ##### Put Mapping
 
 Requires `_index` and `_type` be specified either via lib config or via options when calling the operation.
 
 `es.indices.putMapping(options, mapping, callback)`
-
-##### Put Warmer
-
-Requires `name`, but this must be specified via options.
-
-`es.indices.putWarmer(options, warmer, callback)`
 
 ##### Refresh
 
@@ -606,10 +572,6 @@ Requires `_index` be specified either via lib config or via options when calling
 
 `es.indices.stats(options, callback)`
 
-##### Status
-
-`es.indices.status(options, callback`
-
 ##### Templates
 
 Requires `name`, but this must be specified via options.
@@ -619,12 +581,6 @@ Requires `name`, but this must be specified via options.
 ##### Update Settings
 
 `es.indices.updateSettings(options, settings, callback)`
-
-##### Warmers
-
-Requires `_index` be specified either via lib config or via options when calling the operation.
-
-`es.indices.warmers(options, callback)`
 
 ### Cluster
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a Node.js module for the [elasticsearch](http://www.elasticsearch.org/) REST API.
 
+NOTE: `node-es` `v0.6` and newer work with ElasticSearch 5 and up.  For older versions of ElasticSearch, prior versions of `node-es` should be used.
+
 [![Build Status](https://travis-ci.org/ncb000gt/node-es.png)](https://travis-ci.org/ncb000gt/node-es) [![Coverage Status](https://coveralls.io/repos/ncb000gt/node-es/badge.png)](https://coveralls.io/r/ncb000gt/node-es)
 
 ## Install

--- a/lib/core.js
+++ b/lib/core.js
@@ -428,60 +428,6 @@ module.exports = function (config, req, self) {
 		return req.post(options, serializedQueries, callback);
 	};
 
-	// Redesigned in ES 1.0 - modifying for issue #38
-	// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html
-	self.percolate = function (options, doc, callback) {
-		if (!callback && typeof doc === 'function') {
-			callback = doc;
-			doc = options;
-			options = {};
-		}
-
-		var err = utils.optionsUndefined(options, config, ['_index', '_type']);
-		if (err) {
-			return callback(err);
-		}
-
-		var
-			index = utils.getIndexSyntax(options, config),
-			type = utils.getTypeSyntax(options, config);
-
-		options.query = utils.exclude(options, paramExcludes);
-
-		options.pathname = utils.pathAppend(index) +
-			utils.pathAppend(type) +
-			utils.pathAppend('_percolate');
-
-		// documentation indicates GET method...
-		// sending POST data via GET not typical, using POST instead
-		return req.post(options, doc, callback);
-	};
-
-	// Redesigned in ES 1.0 - modifying for issue #38
-	// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html
-	self.registerPercolator = function (options, query, callback) {
-		if (!callback && typeof query === 'function') {
-			callback = query;
-			query = options;
-			options = {};
-		}
-
-		var err = utils.optionsUndefined(options, config, ['_index', '_id']);
-		if (err) {
-			return callback(err);
-		}
-
-		var
-			index = utils.getIndexSyntax(options, config);
-
-		options.pathname =
-			utils.pathAppend(index) +
-			utils.pathAppend('.percolator') +
-			utils.pathAppend(options._id);
-
-		return req.put(options, query, callback);
-	};
-
 	// http://www.elasticsearch.org/guide/reference/api/search/
 	// .query to ease backwards compatibility
 	self.search = self.query = function (options, query, callback) {
@@ -512,7 +458,6 @@ module.exports = function (config, req, self) {
 	};
 
 	// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-scroll.html
-	// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html#scan
 	self.scroll = function (options, scrollId, callback) {
 		if (!callback && typeof scrollId === 'function') {
 			callback = scrollId;
@@ -553,32 +498,6 @@ module.exports = function (config, req, self) {
 			utils.pathAppend('_suggest');
 
 		return req.post(options, query, callback);
-	};
-
-	// Redesigned in ES 1.0 - modifying for issue #38
-	// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html
-	self.unregisterPercolator = function (options, callback) {
-		if (!callback && typeof options === 'function') {
-			callback = options;
-			options = {};
-		}
-
-		var err = utils.optionsUndefined(options, config, ['_index', '_id']);
-		if (err) {
-			return callback(err);
-		}
-
-		var
-			index = utils.getIndexSyntax(options, config);
-
-		options.query = utils.exclude(options, paramExcludes);
-
-		options.pathname =
-			utils.pathAppend(index) +
-			utils.pathAppend('.percolator') +
-			utils.pathAppend(options._id);
-
-		return req.delete(options, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/update/

--- a/lib/indices.js
+++ b/lib/indices.js
@@ -134,11 +134,7 @@ module.exports = function (config, req, self) {
 
 		options.pathname = utils.pathAppend(index);
 
-		if (data && data.mappings) {
-			return req.post(options, data, callback);
-		} else {
-			return req.put(options, data, callback);
-		}
+		return req.put(options, data, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
@@ -240,29 +236,8 @@ module.exports = function (config, req, self) {
 		return req.delete(options, callback);
 	};
 
-	// http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
-	self.deleteWarmer = function (options, callback) {
-		if (!callback && typeof options === 'function') {
-			callback = options;
-			options = {};
-		}
-
-		var err = utils.optionsUndefined(options, config, ['_index', 'name']);
-		if (err) {
-			return callback(err);
-		}
-
-		var index = utils.getIndexSyntax(options, config);
-
-		options.pathname = utils.pathAppend(index) +
-			utils.pathAppend('_warmer') +
-			utils.pathAppend(options.name);
-
-		return req.delete(options, callback);
-	};
-
-	// http://www.elasticsearch.org/guide/reference/api/admin-indices-indices-exists/
-	// http://www.elasticsearch.org/guide/reference/api/admin-indices-types-exists/
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
+	// https://www.elastic.co/guide/en/elasticsearch/reference/5.5/indices-types-exists.html
 	// Also replicated (somewhat) in core... core.exists is more flexible, however
 	self.exists = function (options, callback) {
 		if (!callback && typeof options === 'function') {
@@ -279,8 +254,7 @@ module.exports = function (config, req, self) {
 			index = utils.getIndexSyntax(options, config),
 			type = utils.getTypeSyntax(options, config);
 
-		options.pathname = utils.pathAppend(index) +
-			utils.pathAppend(type);
+		options.pathname = type ? (utils.pathAppend(index) + '/_mapping' + utils.pathAppend(type)) : utils.pathAppend(index);
 
 		return req.head(options, function (err, data) {
 			if (err) {
@@ -292,7 +266,6 @@ module.exports = function (config, req, self) {
 
 					return callback(null, data);
 				}
-
 				return callback(err);
 			}
 
@@ -359,23 +332,6 @@ module.exports = function (config, req, self) {
 		return req.post(options, callback);
 	};
 
-	// http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize/
-	self.optimize = function (options, callback) {
-		if (!callback && typeof options === 'function') {
-			callback = options;
-			options = {};
-		}
-
-		var index = utils.getIndexSyntax(options, config);
-
-		options.query = utils.exclude(options, paramExcludes);
-
-		options.pathname = utils.pathAppend(index) +
-			utils.pathAppend('_optimize');
-
-		return req.post(options, callback);
-	};
-
 	// http://www.elasticsearch.org/guide/reference/api/admin-indices-put-mapping/
 	self.putMapping = function (options, mapping, callback) {
 		if (!callback && typeof mapping === 'function') {
@@ -400,31 +356,6 @@ module.exports = function (config, req, self) {
 			(index ? utils.pathAppend(type) : '');
 
 		return req.put(options, mapping, callback);
-	};
-
-	// http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
-	self.putWarmer = function (options, warmer, callback) {
-		if (!callback && typeof warmer === 'function') {
-			callback = warmer;
-			warmer = options;
-			options = {};
-		}
-
-		var err = utils.optionsUndefined(options, config, ['name']);
-		if (err) {
-			return callback(err);
-		}
-
-		var
-			index = utils.getIndexSyntax(options, config),
-			type = utils.getTypeSyntax(options, config);
-
-		options.pathname = utils.pathAppend(index) +
-			utils.pathAppend(type) +
-			utils.pathAppend('_warmer') +
-			utils.pathAppend(options.name);
-
-		return req.put(options, warmer, callback);
 	};
 
 	// http://www.elasticsearch.org/guide/reference/api/admin-indices-refresh/
@@ -571,29 +502,6 @@ module.exports = function (config, req, self) {
 			utils.pathAppend('_settings');
 
 		return req.put(options, settings, callback);
-	};
-
-	// http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
-	self.warmers = function (options, callback) {
-		if (!callback && typeof options === 'function') {
-			callback = options;
-			options = {};
-		}
-
-		var err = utils.optionsUndefined(options, config, ['_index']);
-		if (err) {
-			return callback(err);
-		}
-
-		var index = utils.getIndexSyntax(options, config);
-
-		options.query = utils.exclude(options, paramExcludes.concat('name'));
-
-		options.pathname = utils.pathAppend(index) +
-			utils.pathAppend('_warmer') +
-			utils.pathAppend(options.name);
-
-		return req.get(options, callback);
 	};
 
 	return thenifyAll.withCallback(self, {});

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,6 +48,12 @@ exports.getFieldSyntax = function (options) {
 		syntax = options.field;
 	}
 
+	if (options.stored_fields && Array.isArray(options.stored_fields)) {
+		syntax = options.stored_fields.join(',');
+	} else if (options.store_field) {
+		syntax = options.store_field;
+	}
+
 	return syntax;
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "es",
   "description": "API around the ElasticSearch RESTful API -- mostly convenience.",
   "main": "index.js",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "author": "Nick Campbell (http://github.com/ncb000gt)",
   "contributors": [
     "Nick Campbell (http://github.com/ncb000gt)",
@@ -10,10 +10,11 @@
     "Richard Marr (http://github.com/richmarr)",
     "Joshua Thomas (http://github.com/brozeph)",
     "Brian Link (https://github.com/cpsubrian)",
-    "Doug Moscrop (https://github.com/dougmoscrop)"
+    "Doug Moscrop (https://github.com/dougmoscrop)",
+    "Robin Momii (http://github.com/rmomii)"
   ],
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.0"
   },
   "keywords": [
     "elastic",

--- a/test/lib/core.js
+++ b/test/lib/core.js
@@ -803,45 +803,6 @@ describe('API: core', function () {
 		});
 	});
 
-	describe('#percolate', function () {
-		var doc = {
-			doc : {
-				breed : 'siamese'
-			}
-		};
-
-		it('should require index', function (done) {
-			delete defaultOptions._index;
-			core.percolate(doc, function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should require type', function (done) {
-			delete defaultOptions._type;
-			core.percolate(doc, function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should set proper method and url path', function (done) {
-			core.percolate(doc, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('POST');
-				data.options.path.should.equals('/dieties/kitteh/_percolate');
-
-				done();
-			});
-		});
-	});
-
 	describe('#query', function () {
 		var query = {
 			query : {
@@ -855,46 +816,6 @@ describe('API: core', function () {
 				should.exist(data);
 				data.options.path.should.equals('/dieties/kitteh/_search');
 				data.options.method.should.equals('POST');
-
-				done();
-			});
-		});
-	});
-
-	describe('#registerPercolator', function () {
-		var query = {
-			query : {
-				term : {
-					name : 'fluffy'
-				}
-			}
-		};
-
-		it('should require index', function (done) {
-			delete defaultOptions._index;
-			core.registerPercolator(query, function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should require _id', function (done) {
-			core.registerPercolator(query, function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should set proper method and url path', function (done) {
-			core.registerPercolator({ _id : 1 }, doc, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('PUT');
-				data.options.path.should.equals('/dieties/.percolator/1');
 
 				done();
 			});
@@ -1008,38 +929,6 @@ describe('API: core', function () {
 				should.exist(data);
 				data.options.path.should.equals('/dieties/kitteh/_suggest');
 				data.options.method.should.equals('POST');
-
-				done();
-			});
-		});
-	});
-
-	describe('#unregisterPercolator', function () {
-		it('should require index', function (done) {
-			delete defaultOptions._index;
-			core.unregisterPercolator(function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should require _id', function (done) {
-			core.unregisterPercolator(function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should set proper method and url path', function (done) {
-			core.unregisterPercolator({ _id : 1 }, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('DELETE');
-				data.options.path.should.equals('/dieties/.percolator/1');
 
 				done();
 			});

--- a/test/lib/indices.js
+++ b/test/lib/indices.js
@@ -243,7 +243,7 @@ describe('API: indices', function () {
 			indices.createIndex(settings, function (err, data) {
 				should.not.exist(err);
 				should.exist(data);
-				data.options.method.should.equals('POST');
+				data.options.method.should.equals('PUT');
 				data.options.path.should.equals('/dieties');
 
 				done();
@@ -396,38 +396,6 @@ describe('API: indices', function () {
 		});
 	});
 
-	describe('#deleteWarmer', function () {
-		it('should require name', function (done) {
-			indices.deleteWarmer(function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should require index', function (done) {
-			delete defaultOptions._index;
-			indices.deleteWarmer(function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should have proper path and method', function (done) {
-			indices.deleteWarmer({ name : 'cat' }, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('DELETE');
-				data.options.path.should.equals('/dieties/_warmer/cat');
-
-				done();
-			});
-		});
-	});
-
 	describe('#exists', function () {
 		it('should require index', function (done) {
 			delete defaultOptions._index;
@@ -453,7 +421,7 @@ describe('API: indices', function () {
 		it('should have proper method and path', function (done) {
 			indices.exists({ _types : ['kitteh', 'cat'] }, function (err, data) {
 				should.not.exist(err);
-				data.options.path.should.equals('/dieties/kitteh,cat');
+				data.options.path.should.equals('/dieties/_mapping/kitteh,cat');
 				data.options.method.should.equals('HEAD');
 
 				done();
@@ -556,31 +524,6 @@ describe('API: indices', function () {
 		});
 	});
 
-	describe('#optimize', function () {
-		it('should have proper index and path when index is omitted', function (done) {
-			delete defaultOptions._index;
-			indices.optimize(function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('POST');
-				data.options.path.should.equals('/_optimize');
-
-				done();
-			});
-		});
-
-		it('should have proper method and path', function (done) {
-			indices.optimize({ _indices : ['dieties', 'devils'], refresh : true }, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('POST');
-				data.options.path.should.equals('/dieties,devils/_optimize?refresh=true');
-
-				done();
-			});
-		});
-	});
-
 	describe('#putMapping', function () {
 		var mapping = {
 			kitteh : {
@@ -618,61 +561,6 @@ describe('API: indices', function () {
 				should.exist(data);
 				data.options.method.should.equals('PUT');
 				data.options.path.should.equals('/dieties,devils/_mapping/kitteh');
-
-				done();
-			});
-		});
-	});
-
-	describe('#putWarmer', function () {
-		var warmer = {
-			query : {
-				match_all : {}
-			},
-			facets : {
-				breed : {
-					terms : { field : 'breed' }
-				}
-			}
-		};
-
-		it('should require index', function (done) {
-			delete defaultOptions._index;
-			indices.putWarmer(warmer, function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should require name', function (done) {
-			indices.putWarmer(warmer, function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should have proper method and path when type is omitted', function (done) {
-			delete defaultOptions._type;
-			indices.putWarmer({ name : 'breed' }, warmer, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('PUT');
-				data.options.path.should.equals('/dieties/_warmer/breed');
-
-				done();
-			});
-		});
-
-		it('should have proper method and path', function (done) {
-			indices.putWarmer({ name : 'breed', _indices : ['dieties', 'devils'] }, warmer, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('PUT');
-				data.options.path.should.equals('/dieties,devils/kitteh/_warmer/breed');
 
 				done();
 			});
@@ -875,40 +763,6 @@ describe('API: indices', function () {
 				should.exist(data);
 				data.options.method.should.equals('PUT');
 				data.options.path.should.equals('/kitteh/_settings');
-
-				done();
-			});
-		});
-	});
-
-	describe('#warmers', function () {
-		it('should require index', function (done) {
-			delete defaultOptions._index;
-			indices.warmers(function (err, data) {
-				should.exist(err);
-				should.not.exist(data);
-
-				done();
-			});
-		});
-
-		it('should have proper path and method when name is omitted', function (done) {
-			indices.warmers(function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('GET');
-				data.options.path.should.equals('/dieties/_warmer');
-
-				done();
-			});
-		});
-
-		it('should have proper path and method', function (done) {
-			indices.warmers({ name : 'cat' }, function (err, data) {
-				should.not.exist(err);
-				should.exist(data);
-				data.options.method.should.equals('GET');
-				data.options.path.should.equals('/dieties/_warmer/cat');
 
 				done();
 			});


### PR DESCRIPTION
@brozeph 

* Original issue: unable to create index through npm module `reindeer` (https://github.com/brozeph/reindeer/) due to ES 5.x change where `createIndex` now only calls `put` instead of `post`
* Updated other methods affected by 5.x changes
* Updated tests